### PR TITLE
feat(ci): Add changelog configuration and initialize empty changelog

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -1,0 +1,28 @@
+{
+  "categories": [
+    "all",
+    "ci",
+    "deps",
+    "scripts",
+    "tests"
+  ],
+  "change_types": [
+    {
+      "short": "feat",
+      "long": "Features"
+    },
+    {
+      "short": "imp",
+      "long": "Improvements"
+    },
+    {
+      "short": "fix",
+      "long": "Bug Fixes"
+    }
+  ],
+  "commit_message": "add changelog entry",
+  "changelog_path": "CHANGELOG.md",
+  "expected_spellings": {},
+  "legacy_version": null,
+  "target_repo": "https://github.com/MalteHerrmann/contracts-testing"
+}

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,4 +1,4 @@
-name: Changelog Linter
+name: Changelog Checks
 
 on:
   push:
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  check-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Changelog for changes
+        uses: tarides/changelog-check-action@v3
+        with:
+          changelog: CHANGELOG.md
+
   lint-changelog:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint-changelog.yaml
+++ b/.github/workflows/lint-changelog.yaml
@@ -1,0 +1,24 @@
+name: Changelog Linter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  lint-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Run changelog linter
+      uses: MalteHerrmann/changelog-lint-action@v0.3.0
+      with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+<!--
+This changelog was created using the `clu` binary
+(https://github.com/MalteHerrmann/changelog-utils).
+-->
+
+# Changelog
+
+## Unreleased
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 This changelog was created using the `clu` binary
 (https://github.com/MalteHerrmann/changelog-utils).
 -->
-
 # Changelog
 
 ## Unreleased
 
+### Features
+
+- (ci) [#1](https://github.com/MalteHerrmann/contracts-testing/pull/1) Add changelog configuration and initialize empty changelog.


### PR DESCRIPTION
This PR sets up the changelog infrastructure for the repository by:

1. Adding a `.clconfig.json` file that configures the changelog generation tool with:
   - Defined categories (all, ci, deps, scripts, tests)
   - Change types (Features, Improvements, Bug Fixes)
   - Other settings for changelog management

2. Creating an initial empty `CHANGELOG.md` file with:
   - A reference to the changelog utility tool
   - An 'Unreleased' section placeholder for future entries

3. Adding the [MalteHerrmann/changelog-lint-action](https://github.com/MalteHerrmann/changelog-lint-action) CI workflow as well as [tarides/changelog-check-action](https://github.com/tarides/changelog-check-action).

This provides the foundation for consistent changelog entries moving forward.